### PR TITLE
sets prevent session fixation to false and removes the JVM route addi…

### DIFF
--- a/images/dotcms/ROOT/srv/templates/dotcms/CONF/dotmarketing-config.properties
+++ b/images/dotcms/ROOT/srv/templates/dotcms/CONF/dotmarketing-config.properties
@@ -27,5 +27,7 @@ felix.felix.fileinstall.dir=/data/shared/felix/load
 
 CACHE_INVALIDATION_TRANSPORT_CLASS={{ $cache_invalidation_transport_class }}
 
+PREVENT_SESSION_FIXATION_ON_LOGIN=false
+
 # END Docker customizations
 

--- a/images/dotcms/ROOT/srv/templates/tomcat/OVERRIDE/conf/server.xml
+++ b/images/dotcms/ROOT/srv/templates/tomcat/OVERRIDE/conf/server.xml
@@ -52,7 +52,7 @@
          on to the appropriate Host (virtual host).
          Documentation at /docs/config/engine.html -->
 
-    <Engine name="Catalina" defaultHost="localhost" jvmRoute="{{ .Env.HOSTNAME }}">
+    <Engine name="Catalina" defaultHost="localhost">
 
 
       <Host name="localhost"  appBase="webapps"


### PR DESCRIPTION
…tion to the jsessionId.

When running a cluster of dotcms that is sticky session based on the jsessionId, the fact that a new jsessionId is generated on login is problematic as this bounces the user to another server and they lose their session.