### PR TITLE
Creating new image to act as a sidecar app for curl (postman) tests at core project

### DIFF
--- a/images/dotcms-curl/Dockerfile
+++ b/images/dotcms-curl/Dockerfile
@@ -1,0 +1,19 @@
+FROM gcr.io/cicd-246518/build-cms-image
+
+#  One of ["TARBALL_URL", "RELEASE", "NIGHTLY", "COMMIT", "TAG" ]
+ARG BUILD_FROM=COMMIT
+#  Value resolved in the context of $BUILD_FROM
+ARG BUILD_ID=HEAD
+
+USER 0
+
+WORKDIR /srv
+
+COPY ROOT/ /
+# Make scripts runable
+RUN find /srv/ -type f -name "*.sh" -exec chmod a+x {} \;
+
+USER 1000000000
+
+ENTRYPOINT ["/sbin/tini", "--", "/srv/entrypoint.sh"]
+CMD ["dotcms"]

--- a/images/dotcms-curl/README.md
+++ b/images/dotcms-curl/README.md
@@ -1,0 +1,64 @@
+# BUILD dotCMS Docker image from arguments 
+
+This version of the dockerfile and requisite build files that are provided with the primary purpose of illustrating dotCMS-distributed image functionality. We encourage you to use the distribution images provided at  https://hub.docker.com/r/dotcms/dotcms/ rather than building your own image.  
+
+Building custom images may create more complexity and challenges as it relates to the ongoing support of your installation.  Please contact support@dotcms.com to inquire about add-on product services available for extended support around Docker.  
+
+Please note that the dotCMS image can be extended via static and dynamic plugins, as well as numerous extension points to the init and configuration functionality.  If you need customized functionality please check documentation on using plugins with docker images before assuming you need to build a custom docker image. 
+
+dotCMS has architected this image to handle many different use cases, providing the best dotCMS product experience while still enabling use of custom functionality with the genuine dotCMS image.
+
+Please send any thoughts or suggestions to improve our docker image to support@dotcms.com. 
+
+If you feel you must create your own custom docker image(s), please contact dotCMS Support to discuss product compatibility and scope-of-support concerns prior to implementation.
+
+
+# Arguments for building dotCMS docker image: 
+
+|  BUILD_FROM  | BUILD_ID                     |
+| ------------ | ---------------              |
+| TARBALL_URL  | URL to tar file              |
+| RELEASE      | Release number               |
+| COMMIT       | Commit hash or branch name to use for build |
+| TAG          | Tag to use for build         |
+
+
+## Examples 
+
+### TARBALL_URL Example 
+```
+docker build --pull --no-cache --build-arg BUILD_FROM=TARBALL_URL --build-arg BUILD_ID=https://dotcms.com/contentAsset/raw-data/523ef132-4a0b-4f17-9d82-eb2cfec779c6/targz/dotcms-2018-03-09_22-10.tar.gz -t dotcms-test .
+
+docker run -it -p 8080:8080 --rm dotcms-test
+```
+
+### RELEASE Example 
+```
+docker build --pull --no-cache --build-arg BUILD_FROM=RELEASE --build-arg BUILD_ID=5.2.0 -t dotcms-test .
+
+docker run -it -p 8080:8080  --rm dotcms-test
+```
+
+### BRANCH Example 
+Where your branch name is `master`.  In this case, becuase a branch is a movable pointer, you need to prune your
+images before building in order to purge your image cache and get a clean build.
+```
+docker build --pull --no-cache --build-arg BUILD_FROM=COMMIT --build-arg BUILD_ID=origin/master -t dotcms-test .
+
+docker run -it -p 8080:8080  --rm dotcms-test
+```
+
+
+### COMMIT Example 
+```
+docker build --pull --no-cache --build-arg BUILD_FROM=COMMIT --build-arg BUILD_ID=c4e97b3 -t dotcms-test .
+
+docker run -it -p 8080:8080  --rm dotcms-test
+```
+
+### TAG Example 
+```
+docker build --pull --no-cache --build-arg BUILD_FROM=TAG --build-arg BUILD_ID=4.2.3-beta -t dotcms-test .
+
+docker run -it -p 8080:8080  --rm dotcms-test
+```

--- a/images/dotcms-curl/ROOT/srv/50-database-config.sh
+++ b/images/dotcms-curl/ROOT/srv/50-database-config.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+source /srv/utils/config-defaults.sh
+
+
+echo "Database config ...."
+if [[ -z "${PROVIDER_DB_DNSNAME}" ]]; then
+  PROVIDER_DB_DRIVER="H2"
+else
+  PROVIDER_DB_DRIVER=$(echo $PROVIDER_DB_DRIVER | tr '[:lower:]' '[:upper:]')
+fi
+
+case "$PROVIDER_DB_DRIVER" in 
+
+    H2)
+        : ${PROVIDER_DB_DBNAME:="h2_dotcms_data"}
+        ;;
+
+    POSTGRES)
+        : ${PROVIDER_DB_DBNAME:="dotcms"}
+        [[ -z "$PROVIDER_DB_USERNAME" ]] && $PROVIDER_DB_USERNAME="postgres"
+        [[ -z "PROVIDER_DB_PASSWORD" ]] && PROVIDER_DB_PASSWORD="postgres"
+        [[ -z "$PROVIDER_DB_PORT" ]] && PROVIDER_DB_PORT="15432"
+        ;;
+
+    MYSQL)
+        : ${PROVIDER_DB_DBNAME:="dotcms"}
+        [[ -z "$PROVIDER_DB_USERNAME" ]] && $PROVIDER_DB_USERNAME="mysql"
+        [[ -z "PROVIDER_DB_PASSWORD" ]] && PROVIDER_DB_PASSWORD="mysql"
+        [[ -z "$PROVIDER_DB_PORT" ]] && PROVIDER_DB_PORT="13306"
+        ;;
+
+    ORACLE)
+        : ${PROVIDER_DB_DBNAME:="XE"}
+        [[ -z "$PROVIDER_DB_USERNAME" ]] && $PROVIDER_DB_USERNAME="oracle"
+        [[ -z "PROVIDER_DB_PASSWORD" ]] && PROVIDER_DB_PASSWORD="oracle"
+        [[ -z "$PROVIDER_DB_PORT" ]] && PROVIDER_DB_PORT="11521"
+        ;;
+
+    MSSQL)
+        : ${PROVIDER_DB_DBNAME:="dotcms"}
+        [[ -z "$PROVIDER_DB_USERNAME" ]] && $PROVIDER_DB_USERNAME="sa"
+        [[ -z "PROVIDER_DB_PASSWORD" ]] && PROVIDER_DB_PASSWORD="dotCMS12345"
+        [[ -z "$PROVIDER_DB_PORT" ]] && PROVIDER_DB_PORT="11433"
+        ;;
+
+    *)
+        echo "Invalid DB driver specified!!"
+        exit 1
+
+esac
+
+
+touch /tmp/DB_CONNECT_TEST
+[[ "$PROVIDER_DB_DRIVER" != "H2" ]] && echo "${PROVIDER_DB_DNSNAME}:${PROVIDER_DB_PORT}" >/tmp/DB_CONNECT_TEST
+
+
+echo "PROVIDER_DB_DRIVER=${PROVIDER_DB_DRIVER}" >>/srv/config/settings.ini
+[[ -n "$PROVIDER_DB_URL" ]] && echo "PROVIDER_DB_URL=${PROVIDER_DB_URL}" >>/srv/config/settings.ini
+echo "PROVIDER_DB_DBNAME=${PROVIDER_DB_DBNAME}" >>/srv/config/settings.ini
+echo "PROVIDER_DB_DNSNAME=${PROVIDER_DB_DNSNAME}" >>/srv/config/settings.ini
+echo "PROVIDER_DB_PORT=${PROVIDER_DB_PORT}" >>/srv/config/settings.ini
+echo "PROVIDER_DB_USERNAME=${PROVIDER_DB_USERNAME}" >>/srv/config/settings.ini
+echo "PROVIDER_DB_PASSWORD=${PROVIDER_DB_PASSWORD}" >>/srv/config/settings.ini
+echo "PROVIDER_DB_MAXCONNS=${PROVIDER_DB_MAXCONNS}" >>/srv/config/settings.ini
+
+
+
+

--- a/images/dotcms-curl/ROOT/srv/utils/config-defaults.sh
+++ b/images/dotcms-curl/ROOT/srv/utils/config-defaults.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+###
+##   Configuration defaults for Docker container configuration and service discovery
+##    Please do not alter this file, but set these as environment variables on the container launch if needed.
+###
+
+set -e
+
+
+## Tomcat config
+
+# Auto-set Tomcat version from container build var, used for proper pathing
+[[ -f /srv/TOMCAT_VERSION ]] && TOMCAT_VERSION=$( cat /srv/TOMCAT_VERSION )
+TOMCAT_HOME=/srv/dotserver/tomcat-${TOMCAT_VERSION}
+
+# Java heap size used for Tomcat/dotCMS app
+: ${CMS_HEAP_SIZE:="1G"}
+
+# Extra JVM args to pass to the Tomcat JVM
+: ${CMS_JAVA_OPTS:=""}
+
+# Maximum number of Tomcat Connector threadpool threads (shared across Connectors)
+: ${CMS_CONNECTOR_THREADS:="200"}
+
+# SMTP hostname for CMS
+: ${CMS_SMTP_HOST:="smtp"}
+
+# dotCMS runas user UID
+: ${CMS_RUNAS_UID:="999999"}
+
+# dotCMS runas group GID
+: ${CMS_RUNAS_GID:="999999"}
+
+## Plugins init (not implemented yet!!)
+: ${CMS_PLUGINS_OSGI_OVERWRITE_SHARED:="false"}
+: ${CMS_PLUGINS_OSGI_FIX_OWNER:="true"}
+
+## Database config
+
+# IP or hostname of database server
+: ${PROVIDER_DB_DNSNAME:=""}
+
+# Database type, one of ["H2","POSTGRES","MYSQL","ORACLE","MSSQL"]
+: ${PROVIDER_DB_DRIVER:="POSTGRES"}
+
+# JDBC-compliant URL to connect to DB (only needed to set custom options, PROVIDER_DB_DNSNAME & PROVIDER_DB_PORT must also be set or use defaults)
+: ${PROVIDER_DB_URL:=""}
+
+# Database tcp port number. If unset, will use default per database type
+: ${PROVIDER_DB_PORT:=""} 
+
+# Database username
+: ${PROVIDER_DB_USERNAME:="dotcmsdbuser"}
+
+# Database password
+: ${PROVIDER_DB_PASSWORD:="password"}
+
+# Maximum number of database connections
+: ${PROVIDER_DB_MAXCONNS:="200"}
+
+
+
+## Discovery note
+#   The following are defined per-image upstream in the build Dockerfile:
+#   - SERVICE_DELAY_DEFAULT_MIN
+#   - SERVICE_DELAY_DEFAULT_STEP
+#   - SERVICE_DELAY_DEFAULT_MAX
+
+
+## Hazelcast config
+
+# IP or hostname of external Hazelcast service (can be multi-valued RR DNS record). Leave unset for embedded Hazelcast
+: ${PROVIDER_HAZELCAST_DNSNAMES:=""}
+: ${PROVIDER_HAZELCAST_SVC_DELAY_MIN:="${SERVICE_DELAY_DEFAULT_MIN}"}
+: ${PROVIDER_HAZELCAST_SVC_DELAY_STEP:="${SERVICE_DELAY_DEFAULT_STEP}"}
+: ${PROVIDER_HAZELCAST_SVC_DELAY_MAX:="${SERVICE_DELAY_DEFAULT_MAX}"}
+: ${PROVIDER_HAZELCAST_GROUPNAME:="dotCMS"}
+: ${PROVIDER_HAZELCAST_GROUPPASSWORD:=""}
+: ${PROVIDER_HAZELCAST_PORT:="5701"}
+
+
+
+## Elasticsearch discovery
+
+# IP or hostname of external Elasticsearch service (can be multi-valued RR DNS record). Leave unset for embedded Elasticsearch
+: ${PROVIDER_ELASTICSEARCH_DNSNAMES:="elasticsearch"}
+: ${PROVIDER_ELASTICSEARCH_SVC_DELAY_MIN:="${SERVICE_DELAY_DEFAULT_MIN}"}
+: ${PROVIDER_ELASTICSEARCH_SVC_DELAY_STEP:="${SERVICE_DELAY_DEFAULT_STEP}"}
+: ${PROVIDER_ELASTICSEARCH_SVC_DELAY_MAX:="${SERVICE_DELAY_DEFAULT_MAX}"}
+# Background ES discovery refresh rate (in seconds)
+: ${PROVIDER_ELASTICSEARCH_SVC_REFRESH:='10'}
+: ${PROVIDER_ELASTICSEARCH_CLUSTER_NAME:="dotCMSContentIndex"}
+: ${PROVIDER_ELASTICSEARCH_PORT_TRANSPORT:="19300"}
+: ${PROVIDER_ELASTICSEARCH_PORT_HTTP:="19200"}
+# Elasticsearch HTTP server will be bound to localhost by default (this is not used by dotCMS). Change address binding to make accessible.
+: ${PROVIDER_ELASTICSEARCH_ADDR_HTTP:="127.0.0.1"}
+# Elasticsearch HTTP server is disabled by default. Set to "true" to enable.
+: ${PROVIDER_ELASTICSEARCH_ENABLE_HTTP:="false"}
+
+
+## Load balancer config
+
+# Default PORT 
+: ${PROVIDER_LOADBALANCER_DNSNAMES:=""}
+: ${PROVIDER_LOADBALANCER_PORT_HTTP:="80"}
+: ${PROVIDER_LOADBALANCER_SVC_DELAY_MIN:="${SERVICE_DELAY_DEFAULT_MIN}"}
+: ${PROVIDER_LOADBALANCER_SVC_DELAY_STEP:="${SERVICE_DELAY_DEFAULT_STEP}"}
+: ${PROVIDER_LOADBALANCER_SVC_DELAY_MAX:="${SERVICE_DELAY_DEFAULT_MAX}"}
+
+
+
+
+

--- a/images/dotcms/Dockerfile
+++ b/images/dotcms/Dockerfile
@@ -1,6 +1,6 @@
 # OpenJDK distributed under GPLv2+Oracle Classpath Exception license (http://openjdk.java.net/legal/gplv2+ce.html)
 # Alpine Linux packages distributed under various licenses including GPL-3.0+ (https://pkgs.alpinelinux.org/packages)
-FROM dotcms/dotcms-seed as build-cms 
+FROM dotcms/dotcms-seed as build-cms
 
 LABEL com.dotcms.contact "support@dotcms.com"
 LABEL com.dotcms.vendor "dotCMS LLC"
@@ -10,13 +10,13 @@ LABEL com.dotcms.description "dotCMS Content Management System"
 ARG BUILD_FROM=COMMIT
 
 #  Value resolved in the context of $BUILD_FROM
-ARG BUILD_ID=HEAD      
+ARG BUILD_ID=HEAD
 
 WORKDIR /srv
 
 # dotCMS core distributed under GPLv3 license (https://github.com/dotCMS/core/blob/master/license.txt)
 COPY build-src/ /build/
-RUN chmod 500 /build/build_dotcms.sh && /build/build_dotcms.sh ${BUILD_FROM} ${BUILD_ID} 
+RUN chmod 500 /build/build_dotcms.sh && /build/build_dotcms.sh ${BUILD_FROM} ${BUILD_ID}
 
 RUN mkdir -p /srv/utils /srv/templates /srv/config /srv/home
 RUN chmod -R 666 /srv && find /srv/ -type d -exec chmod a+x {} \;
@@ -35,7 +35,7 @@ RUN apk --no-cache upgrade \
     && apk add --no-cache bash openssl ca-certificates gnupg grep sed tini nss s6-dns \
     && update-ca-certificates 
 
-RUN apk --no-cache add libc6-compat tomcat-native curl && apk add libsass --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ 
+RUN apk --no-cache add libc6-compat tomcat-native curl && apk add libsass --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/
 
 # This is a nasty hack for libjsass, Alpine 3.9 no longer has a deprecated symlink in /lib
 RUN [ ! -e /lib/ld-linux-x86-64.so.2 ] &&  ln -s $(readlink /lib64/ld-linux-x86-64.so.2) /lib/ld-linux-x86-64.so.2 || :
@@ -66,7 +66,7 @@ ENV SERVICE_DELAY_DEFAULT_MAX 30
 ## Ports
 # Direct connect
 EXPOSE 8080
-# Connect from proxy, HTTP/80, non-secure 
+# Connect from proxy, HTTP/80, non-secure
 EXPOSE 8081
 # Connect from proxy, HTTPS/443, secure
 EXPOSE 8082

--- a/images/dotcms/ROOT/srv/90-dockerize-config.sh
+++ b/images/dotcms/ROOT/srv/90-dockerize-config.sh
@@ -10,7 +10,7 @@ find /srv/plugins -mindepth 2 -maxdepth 2 -type f -name config-templatable.txt -
 for template in $( cat /srv/config/templatable.txt |sort -u ); do
     template_evaled=$( eval echo "${template}" )
     echo "Adding template \"${template_evaled}\""
-     DOCKERIZE_TEMPLATES="${DOCKERIZE_TEMPLATES} -template ${template_evaled}:${template_evaled}"
+    DOCKERIZE_TEMPLATES="${DOCKERIZE_TEMPLATES} -template ${template_evaled}:${template_evaled}"
 done
 
 if [[ -e /srv/config/settings.ini ]]; then

--- a/images/dotcms/ROOT/srv/templates/dotcms/OVERRIDE/WEB-INF/classes/db.properties
+++ b/images/dotcms/ROOT/srv/templates/dotcms/OVERRIDE/WEB-INF/classes/db.properties
@@ -13,7 +13,7 @@ connectionTestQuery=SELECT 1
 {{ else if eq .Env.PROVIDER_DB_DRIVER "MYSQL" }}
 ##MySQL default configuration
 driverClassName=com.mysql.jdbc.Driver
-jdbcUrl={{ with .Env.PROVIDER_DB_URL }}{{ . }}{{ else }}jdbc:mysql://{{ .Env.PROVIDER_DB_DNSNAME }}:{{ .Env.PROVIDER_DB_PORT }}/{{ .Env.PROVIDER_DB_DBNAME }}?characterEncoding=UTF-8&amp;useLegacyDatetimeCode=false&amp;serverTimezone=UTC{{ end }}
+jdbcUrl={{ with .Env.PROVIDER_DB_URL }}{{ . }}{{ else }}jdbc:mysql://{{ .Env.PROVIDER_DB_DNSNAME }}:{{ .Env.PROVIDER_DB_PORT }}/{{ .Env.PROVIDER_DB_DBNAME }}?characterEncoding=UTF-8&useLegacyDatetimeCode=false&serverTimezone=UTC{{ end }}
 connectionTestQuery=SELECT 1
 
 {{ else if eq .Env.PROVIDER_DB_DRIVER "ORACLE" }}

--- a/images/dotcms/build-src/build_dotcms.sh
+++ b/images/dotcms/build-src/build_dotcms.sh
@@ -24,7 +24,7 @@ build_by_commit() {
     mkdir -p /build/src && cd /build/src
 
     cd /build/src/core
-    git clean -f -d 
+    git clean -f -d
     git pull
     
     echo "Checking out commit/tag/branch: $1"


### PR DESCRIPTION
New image "extends" the one defined at https://github.com/dotCMS/docker/tree/master/images/dotcms with some particular behaviors to play along with core's postman tests.