### PR TITLE
Tomcat resolve

### DIFF
--- a/images/dotcms/Dockerfile
+++ b/images/dotcms/Dockerfile
@@ -12,14 +12,11 @@ ARG BUILD_FROM=COMMIT
 #  Value resolved in the context of $BUILD_FROM
 ARG BUILD_ID=HEAD
 
-# Tomcat version
-ARG TOMCAT_VERSION=""
-
 WORKDIR /srv
 
 # dotCMS core distributed under GPLv3 license (https://github.com/dotCMS/core/blob/master/license.txt)
 COPY build-src/ /build/
-RUN chmod 500 /build/build_dotcms.sh && /build/build_dotcms.sh ${BUILD_FROM} ${BUILD_ID} ${TOMCAT_VERSION}
+RUN chmod 500 /build/build_dotcms.sh && /build/build_dotcms.sh ${BUILD_FROM} ${BUILD_ID}
 
 RUN mkdir -p /srv/utils /srv/templates /srv/config /srv/home
 RUN chmod -R 666 /srv && find /srv/ -type d -exec chmod a+x {} \;

--- a/images/dotcms/build-src/build_dotcms.sh
+++ b/images/dotcms/build-src/build_dotcms.sh
@@ -40,7 +40,7 @@ build_by_commit() {
     git checkout ${1}
   fi
 
-  cd dotCMS && ./gradlew --stacktrace clonePullTomcatDist createDistPrep -PuseGradleNode=false
+  cd dotCMS && ./gradlew clonePullTomcatDist createDistPrep -PuseGradleNode=false
   find ../dist/  -name "*.sh" -exec chmod 500 {} \;
   mv ../dist/* "${build_target_dir}"
 }

--- a/images/dotcms/build-src/build_dotcms.sh
+++ b/images/dotcms/build-src/build_dotcms.sh
@@ -6,7 +6,6 @@ echo "Executing: $0 $@"
 
 build_source=$1
 build_id=$2
-tomcat_version=$3
 echo "Build source: $build_source"
 echo "Build id: $build_id"
 
@@ -35,7 +34,7 @@ build_by_commit() {
   if [[ ${is_release} == true ]]; then
     echo "Executing: git checkout tags/${1} -b ${1}"
     git checkout tags/${1} -b ${1}
-  else
+  elif [[ "${1}" != 'master' ]]; then
     echo "Executing: git checkout ${1}"
     git checkout ${1}
   fi
@@ -50,8 +49,11 @@ set_tomcat_dir() {
   display_tomcat_version=$(echo ${tomcat_versions} | tr '\n' ' ')
   echo "Found tomcat installations: ${display_tomcat_version}"
 
+  eval $(cat gradle.properties | grep tomcatInstallVersion | tr -d '[:space:]')
+  echo "Found tomcat_version=\"${tomcatInstallVersion}\" from gradle.properties"
+  tomcat_version="${tomcatInstallVersion}"
+
   if [[ -n "${tomcat_version}" ]]; then
-    echo "Provided Tomcat version: ${tomcat_version}"
     if [[ -n $(echo "${tomcat_versions}" | grep -oP "${tomcat_version}") ]]; then
       echo "Matched tomcat_version: ${tomcat_version} with installed"
     else
@@ -59,12 +61,13 @@ set_tomcat_dir() {
       exit 1
     fi
   else
+    echo 'Could not find a provided tomcat version, falling back to whatever is within /srv/dotserver/'
     tomcat_version=$(find /srv/dotserver/ -type d -name tomcat-* | grep -oP "(?<=tomcat-)[0-9]{1}\.[0-9]{1}\.[0-9]+$" | sort -n | tail -n 1)
     [[ -z "${tomcat_version}" ]] && echo "ERROR: Unable to determine Tomcat version" && exit 1
   fi
 
   echo "Using tomcat_version=${tomcat_version}"
-  echo ${tomcat_version} >/srv/TOMCAT_VERSION
+  echo ${tomcat_version} > /srv/TOMCAT_VERSION
 }
 
 case "${build_source}" in


### PR DESCRIPTION
Changes introduced to resolve tomcat version based on what is found at the core's `gradle.properties` file since it holds the official tomcat version for that specific branch of `core`.
No more providing the tomcat version through env var.