### PR TITLE
Hide passwords from output during initial start of dotCMS

### DIFF
--- a/images/dotcms/ROOT/srv/90-dockerize-config.sh
+++ b/images/dotcms/ROOT/srv/90-dockerize-config.sh
@@ -21,7 +21,7 @@ if [[ -e /srv/config/settings.ini ]]; then
 fi
 
 echo "Applying config:"
-cat /srv/config/settings.ini | sed 's/^/  /g'
+cat /srv/config/settings.ini | sed 's/^/  /g' | sed 's/PASSWORD=.*/PASSWORD=<hidden>/g'
 
 rm /srv/config/settings.ini
 


### PR DESCRIPTION
**Problem**
All settings derived from environment variables are stored in `/srv/config/settings.ini` and eventually catted to standard output. This includes passwords that could be picked up by log aggregation services and later viewed as plain text by users who should otherwise not have access to them.

**Change**
Added an additional pipe to `sed` to replace password contents with `<hidden>` in the line of code catting the contents of the `settings.ini` file.