### PR TITLE
This change is required to be able to debug after java 9

### DIFF
--- a/images/dotcms/ROOT/srv/entrypoint.sh
+++ b/images/dotcms/ROOT/srv/entrypoint.sh
@@ -35,7 +35,7 @@ if [[ "${1}" == "dotcms" || -z "${1}" ]]; then
     echo "DB Connect Test: ${DB_CONNECT_TEST}"
 
     if [[ ${DEBUG} == true ]]; then
-      export CATALINA_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000'
+      export CATALINA_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8000'
     fi
 
     if [[ -n "$DB_CONNECT_TEST" ]]; then


### PR DESCRIPTION
Some security restrictions were included after java 9. For that reason, the wildcard is required